### PR TITLE
Fixed script URLs

### DIFF
--- a/src/UI/Views/Views/Shared/AdminPlugin.Master
+++ b/src/UI/Views/Views/Shared/AdminPlugin.Master
@@ -20,9 +20,9 @@
                 <%= Html.CssLink(EPiServer.Web.PageExtensions.ThemeUtility.GetCssThemeUrl(Page, "IE.css"))%>
         <![endif]-->
         <%= Html.ScriptResource(EPiServer.UriSupport.ResolveUrlFromUtilBySettings("javascript/episerverscriptmanager.js"))%>
-        <%= Html.ScriptResource(EPiServer.UriSupport.ResolveUrlFromUtilBySettings("javascript/system.js")) %>
-        <%= Html.ScriptResource(EPiServer.UriSupport.ResolveUrlFromUtilBySettings("javascript/dialog.js")) %>
-        <%= Html.ScriptResource(EPiServer.UriSupport.ResolveUrlFromUtilBySettings("javascript/system.aspx")) %>
+        <%= Html.ScriptResource(EPiServer.UriSupport.ResolveUrlFromUIBySettings("javascript/system.js")) %>
+        <%= Html.ScriptResource(EPiServer.UriSupport.ResolveUrlFromUIBySettings("javascript/dialog.js")) %>
+        <%= Html.ScriptResource(EPiServer.UriSupport.ResolveUrlFromUIBySettings("javascript/system.aspx")) %>
         
         <asp:ContentPlaceHolder ID="TitleContent" runat="server" />
 </head>


### PR DESCRIPTION
URLs were rendering as /Util/javascript/\* when they should be /EPiServer/CMS/javascript/*
